### PR TITLE
Remove deprecated code mapping an assertion fail to a Solidity function

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ UNIT_TEST = 3
 
 ```
 # Start testing
-$ python oyenete/run_tests.py
+$ python oyente/run_tests.py
 ```
 
 After running the testing program, the result would display a status for each testcase:

--- a/oyente/assertion.py
+++ b/oyente/assertion.py
@@ -13,15 +13,6 @@ class Assertion:
         # SMT2 query to decide the assertion
         self.query = None
 
-        # Solidity function that might contain this assertion
-        self.function = None
-
-        # Branch that led to the assertion failure
-        self.path = None
-
-        # Symbolic constraints of that path
-        self.sym = None
-
         # Program counter of the ASSERTFAIL
         self.pc = -1
 
@@ -30,24 +21,6 @@ class Assertion:
 
     def get_pc(self):
         return self.pc
-
-    def set_sym(self, sym):
-        self.sym = sym
-
-    def get_sym(self):
-        return self.sym
-
-    def set_path(self, path):
-        self.path = path
-
-    def get_path(self):
-        return self.path
-
-    def set_function(self, function):
-        self.function = function
-
-    def get_function(self):
-        return self.function
 
     def get_block_from(self):
         return self.block_from
@@ -71,24 +44,15 @@ class Assertion:
         self.query = query
 
     def get_log(self):
+        s = ""
         #s += "SMT2 query:\n" + str(self.query) + "\n"
-        #  s = "Violated: " + str(self.violated) + "\n"
-        s = "Function: "
-        if self.function == None:
-            s += "?\n"
-        else:
-            s += self.function + "\n"
-        #  if self.violated:
-            #  s += "Model:\n"
-            #  for decl in self.model.decls():
-                #  s += str(decl.name()) + " = " + str(self.model[decl]) + ", "
+        #s += "Violated: " + str(self.violated) + "\n"
+        #if self.violated:
+        #    s += "Model:\n"
+        #    for decl in self.model.decls():
+        #        s += str(decl.name()) + " = " + str(self.model[decl]) + ", "
         return s
 
     def __str__(self):
-        s += "^\n"
-        s += "Function: "
-        if self.function == None:
-            s += "?\n"
-        else:
-            s += self.function + "\n"
+        s = ""
         return s

--- a/oyente/oyente.py
+++ b/oyente/oyente.py
@@ -88,7 +88,7 @@ def analyze(processed_evm_file, disasm_file, source_map = None):
         of.write(disasm_out)
 
     # Run symExec
-    if source_map:
+    if source_map != None:
         symExec.main(disasm_file, args.source, source_map)
     else:
         symExec.main(disasm_file, args.source)
@@ -192,7 +192,7 @@ def main():
         with open(processed_evm_file, 'w') as f:
             f.write(removeSwarmHash(evm))
 
-        analyze(processed_evm_file, disasm_file, True)
+        analyze(processed_evm_file, disasm_file)
 
         remove_temporary_file(disasm_file)
         remove_temporary_file(processed_evm_file)

--- a/oyente/source_map.py
+++ b/oyente/source_map.py
@@ -36,13 +36,6 @@ class SourceMap:
     def get_positions(self):
         return self.positions
 
-    def retrieveFunctionSignatures(self):
-        cmd = "solc --combined-json hashes %s"
-        out = run_solc_compiler(cmd, SourceMap.filename)
-        out = out[0]
-        out = json.loads(out)
-        return {"0x" + fun_sig: fun_name for fun_name, fun_sig in out['contracts'][self.cname]['hashes'].iteritems()}
-
     def __load_source(self):
         source = ""
         with open(self.__get_filename(), 'r') as f:

--- a/oyente/symExec.py
+++ b/oyente/symExec.py
@@ -163,13 +163,15 @@ def detect_bugs():
     reentrancy_bug_found = any([v for sublist in reentrancy_all_paths for v in sublist])
     if not isTesting():
         s = "\t  Reentrancy bug exists: %s" % reentrancy_bug_found
-        if reentrancy_bug_found:
+        if reentrancy_bug_found and source_map != None:
             for pc in global_problematic_pcs["reentrancy_bug"]:
                 s += "\n%s" % source_map.to_str(pc)
         log.info(s)
     results['reentrancy'] = reentrancy_bug_found
 
     if global_params.CHECK_ASSERTIONS:
+        if source_map == None:
+            raise("Assertion checks need a Source Map")
         assertion_fails = [asrt for asrt in assertions if asrt.is_violated() and "assert" in source_map.find_source_code(asrt.get_pc())]
         is_fail = len(assertion_fails) > 0
         results['assertion_failure'] = is_fail
@@ -327,7 +329,7 @@ def detect_time_dependency():
 
     if not isTesting():
         s = "\t  Time Dependency: \t %s" % is_dependant
-        if pc != -1:
+        if pc != -1 and source_map != None:
             s += "\n%s" % source_map.to_str(pc)
         log.info(s)
     results['time_dependency'] = is_dependant
@@ -376,8 +378,9 @@ def detect_money_concurrency():
     if len(concurrency_paths) > 0:
         if not isTesting():
             s = "\t  Concurrency found in paths: %s" % str(concurrency_paths)
-            for pc in pcs:
-                s += "\n%s" % source_map.to_str(pc)
+            if source_map != None:
+                for pc in pcs:
+                    s += "\n%s" % source_map.to_str(pc)
             log.info(s)
         results['concurrency'] = True
     else:
@@ -456,7 +459,9 @@ def collect_vertices(tokens):
     wait_for_push = False
     is_new_block = False
     count = 0
-    positions = source_map.get_positions()
+    positions = []
+    if source_map != None:
+        positions = source_map.get_positions()
     length = len(positions)
 
     for tok_type, tok_string, (srow, scol), _, line_number in tokens:
@@ -2078,7 +2083,7 @@ def run_callstack_attack():
 
     if not isTesting():
         s = "\t  CallStack Attack: \t %s" % result
-        if result:
+        if result and source_map != None:
             s += "\n %s" % source_map.to_str(pc)
         log.info(s)
     results['callstack'] = result


### PR DESCRIPTION
Since the newer version of ``solc`` fixed some false positive cases on assertion fails (should be ``REVERT``) and the recent work on Source Map already maps an assertion fail back to the ``assert`` in the Solidity code (pretty awesomely btw), the code that I had written before trying to map the assertion fail back to a Solidity function and identifying false positives is not necessary anymore. I kept the ``model`` though, since it might be useful at some point.

The unit tests were raising an exception, because the global var ``source_map`` wasn't initialized when there was no Solidity code (for obvious reasons). I guarded the pieces of code that use ``source_map`` and now the unit tests work with ``UNIT_TEST`` equals both 2 and 3. 