### PR TITLE
Correction in how to run docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ docker pull luongnguyen/oyente && docker run -i -t luongnguyen/oyente
 To evaluate the greeter contract inside the container, run:
 
 ```
-cd /oyente && python oyente.py -s greeter.sol
+cd /oyente/oyente && python oyente.py -s greeter.sol
 ```
 
 and you are done!


### PR DESCRIPTION
The python file is in `/oyente/oyente` so after we exec into the container, we need to `cd /oyente/oyente`.

Since working directory is `/oyente` we can use `cd oyente` also. So we can use either `cd oyente` or `cd /oyente/oyente`. Second one looks more informative.