### PR TITLE
Bug fix in AST helper when contract is empty

### DIFF
--- a/oyente/ast_helper.py
+++ b/oyente/ast_helper.py
@@ -31,9 +31,10 @@ class AstHelper:
             baseContracts = self.get_linearized_base_contracts(node["id"], contracts["contractsById"])
             baseContracts = list(reversed(baseContracts))
             for ctr in baseContracts:
-                for item in ctr["children"]:
-                    if item["name"] == "VariableDeclaration":
-                        stateVar.append(item)
+                if "children" in ctr:
+                    for item in ctr["children"]:
+                        if item["name"] == "VariableDeclaration":
+                            stateVar.append(item)
             return stateVar
 
     def extract_states_definitions(self, sourcesList, contracts=None):


### PR DESCRIPTION
Oyente would crash for the following contract:
```
contract Test {
}
```
because of the access to `ctr["children"]`.
Nothing really serious, but well, better not crash.