### PR TITLE
The option -e or --evm doesn't work. Minor error

### DIFF
--- a/oyente/input_helper.py
+++ b/oyente/input_helper.py
@@ -229,7 +229,7 @@ class InputHelper:
         tmp_files = self._get_temporary_files(target)
         if not self.evm:
             self._rm_file(tmp_files["evm"])
-        self._rm_file(tmp_files["disasm"])
+            self._rm_file(tmp_files["disasm"])
         self._rm_file(tmp_files["log"])
 
     def _rm_file(self, path):

--- a/oyente/oyente.py
+++ b/oyente/oyente.py
@@ -66,7 +66,7 @@ def has_dependencies_installed():
 def analyze_bytecode():
     global args
 
-    helper = InputHelper(InputHelper.BYTECODE, source=args.source)
+    helper = InputHelper(InputHelper.BYTECODE, source=args.source,evm=args.evm)
     inp = helper.get_inputs()[0]
 
     result, exit_code = symExec.run(disasm_file=inp['disasm_file'])
@@ -100,11 +100,11 @@ def analyze_solidity(input_type='solidity'):
     global args
 
     if input_type == 'solidity':
-        helper = InputHelper(InputHelper.SOLIDITY, source=args.source, compilation_err=args.compilation_error, root_path=args.root_path, remap=args.remap, allow_paths=args.allow_paths)
+        helper = InputHelper(InputHelper.SOLIDITY, source=args.source, evm=args.evm, compilation_err=args.compilation_error, root_path=args.root_path, remap=args.remap, allow_paths=args.allow_paths)
     elif input_type == 'standard_json':
-        helper = InputHelper(InputHelper.STANDARD_JSON, source=args.source, allow_paths=args.allow_paths)
+        helper = InputHelper(InputHelper.STANDARD_JSON, source=args.source, evm=args.evm, allow_paths=args.allow_paths)
     elif input_type == 'standard_json_output':
-        helper = InputHelper(InputHelper.STANDARD_JSON_OUTPUT, source=args.source)
+        helper = InputHelper(InputHelper.STANDARD_JSON_OUTPUT, source=args.source, evm=args.evm)
     inputs = helper.get_inputs()
     results, exit_code = run_solidity_analysis(inputs)
     helper.rm_tmp_files()


### PR DESCRIPTION
The option -e or --evm doesn't work. It's never used in oyente.py so InputHelper assigns to evm option the default value (False) and the evm file is always deleted although you specify the option -e (not to delete it). 
I think that keeping the disassembly file could be also interesting, as it contains a visual representation of the bytecode corresponding to the solidity file analyzed. This is why I move the rm_file(tmp_files["disasm"]) inside the conditional statement in input_helper.py