### PR TITLE
Fix sym_exec_ins bug

### DIFF
--- a/oyente/symExec.py
+++ b/oyente/symExec.py
@@ -1413,6 +1413,7 @@ def sym_exec_ins(params, block, instr, func_call, current_func_name):
         else:
             raise ValueError('STACK underflow')
     elif opcode == "CODESIZE":
+        global_state["pc"] = global_state["pc"] + 1
         if g_disasm_file.endswith('.disasm'):
             evm_file_name = g_disasm_file[:-7]
         else:


### PR DESCRIPTION
This is a minor bug.

`CODESIZE` instruction does not increase program counter.

It may result in imprecise analysis when the target contract contains
`CODESIZE` instruction.