### PR TITLE
ci(Travis): remove unsupported python version from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 install:


### PR DESCRIPTION
web3 currently requires python version "> 3.5, < 4". So removing unsupported version from Travis CI.