### PR TITLE
false recognition of library.

### DIFF
--- a/oyente/input_helper.py
+++ b/oyente/input_helper.py
@@ -115,7 +115,8 @@ class InputHelper:
         else:
             out = run_command(cmd)
 
-        libs = re.findall(r"_+(.*?)_+", out)
+        noinfo_out = re.sub(r"\n======= (.*?) =======\nBinary of the runtime part: ", "", out)
+        libs = re.findall(r"_+(.*?)_+", noinfo_out)
         libs = set(libs)
         if libs:
             return self._link_libraries(self.source, libs)


### PR DESCRIPTION
When solc output is like below, oyente recoginizes it is library.

// example
======= /root/work/tagomaru/truffle_project/MetaCoin/node_modules/zeppelin-solidity/contracts/ownership/Ownable.sol:Ownable =======
Binary:
6080604052348015610...

In this case, libs in liine 118 is '[u'project/MetaCoin/node']'.

Then,  incorrectly steps into _link_libraries func and fails...

I added temporary variable 'noinfo_out ' which has no contract file info for re.findall.