### PR TITLE
build(Dockerfile): fix apt install package dependency conflict on node-gyp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,18 +6,21 @@ FROM ethereum/solc:${SOLC_VERSION} as solc
 
 FROM ubuntu:bionic
 
+ARG NODEREPO=node_8.x
 
 LABEL maintainer "Luong Nguyen <luongnt.58@gmail.com>"
 
 SHELL ["/bin/bash", "-c", "-l"]
 RUN apt-get update && apt-get -y upgrade
 RUN apt-get install -y wget unzip python-virtualenv git build-essential software-properties-common curl
+RUN curl -s 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key' | apt-key add -
+RUN apt-add-repository "deb https://deb.nodesource.com/${NODEREPO} $(lsb_release -c -s) main"
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update
 RUN apt-get install -y musl-dev golang-go python3 python3-pip python-pip \
         bison zlib1g-dev libyaml-dev libssl-dev libgdbm-dev libreadline-dev \
-	zlib1g-dev libreadline-dev npm libyaml-dev libsqlite3-dev sqlite3 \
+	zlib1g-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 \
         libxml2-dev libxslt1-dev libcurl4-openssl-dev libffi-dev nodejs yarn && \
         apt-get clean
 


### PR DESCRIPTION
Before this PR, the `Dockerfile` can't be built. This PR is based on PR https://github.com/melonproject/oyente/pull/355 . You should merge https://github.com/melonproject/oyente/pull/355 before merging this.

`libssl-dev` and `npm` both have dependency `node-gyp`. But the version they require is in conflict. Install newer version of `npm` will solve this.
See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=850660

This solution is to install `nodejs` and `npm` from (semi-)official apt repo "nodesource" which is recommended by nodejs.org .
`npm` is no longer a separate package (included in `nodejs`).