### PR TITLE
feat: allow only processing specified contracts

### DIFF
--- a/oyente/global_params.py
+++ b/oyente/global_params.py
@@ -54,3 +54,6 @@ GENERATE_TEST_CASES = 0
 
 # Run Oyente in parallel
 PARALLEL = 0
+
+# Iterable of targeted smart contract names
+TARGET_CONTRACTS = None

--- a/oyente/input_helper.py
+++ b/oyente/input_helper.py
@@ -87,7 +87,7 @@ class InputHelper:
                     'disasm_file': disasm_file
                 })
         if targetContracts is not None and not inputs:
-            raise ValueError("Targeted contract wasn't found in the input! No contract was processed!")
+            raise ValueError("Targeted contracts weren't found in the source code!")
         return inputs
 
     def rm_tmp_files(self):

--- a/oyente/input_helper.py
+++ b/oyente/input_helper.py
@@ -56,7 +56,7 @@ class InputHelper:
             else:
                 setattr(self, attr, val)
 
-    def get_inputs(self):
+    def get_inputs(self, targetContracts=None):
         inputs = []
         if self.input_type == InputHelper.BYTECODE:
             with open(self.source, 'r') as f:
@@ -70,6 +70,8 @@ class InputHelper:
             self._prepare_disasm_files_for_analysis(contracts)
             for contract, _ in contracts:
                 c_source, cname = contract.split(':')
+                if targetContracts is not None and cname not in targetContracts:
+                    continue
                 c_source = re.sub(self.root_path, "", c_source)
                 if self.input_type == InputHelper.SOLIDITY:
                     source_map = SourceMap(contract, self.source, 'solidity', self.root_path, self.remap, self.allow_paths)
@@ -84,6 +86,8 @@ class InputHelper:
                     'c_name': cname,
                     'disasm_file': disasm_file
                 })
+        if targetContracts is not None and not inputs:
+            raise ValueError("Targeted contract wasn't found in the input! No contract was processed!")
         return inputs
 
     def rm_tmp_files(self):

--- a/oyente/oyente.py
+++ b/oyente/oyente.py
@@ -106,7 +106,7 @@ def analyze_solidity(input_type='solidity'):
         helper = InputHelper(InputHelper.STANDARD_JSON, source=args.source, evm=args.evm, allow_paths=args.allow_paths)
     elif input_type == 'standard_json_output':
         helper = InputHelper(InputHelper.STANDARD_JSON_OUTPUT, source=args.source, evm=args.evm)
-    inputs = helper.get_inputs()
+    inputs = helper.get_inputs(global_params.TARGET_CONTRACTS)
     results, exit_code = run_solidity_analysis(inputs)
     helper.rm_tmp_files()
 
@@ -125,6 +125,8 @@ def main():
     group.add_argument("-s",  "--source",    type=str, help="local source file name. Solidity by default. Use -b to process evm instead. Use stdin to read from stdin.")
     group.add_argument("-ru", "--remoteURL", type=str, help="Get contract from remote URL. Solidity by default. Use -b to process evm instead.", dest="remote_URL")
 
+    parser.add_argument("-cnames", "--target-contracts", type=str, nargs="+", help="The name of targeted contracts. If specified, only the specified contracts in the source code will be processed. By default, all contracts in Solidity code are processed.")
+    
     parser.add_argument("--version", action="version", version="oyente version 0.2.7 - Commonwealth")
 
     parser.add_argument("-rmp", "--remap",          help="Remap directory paths", action="store", type=str)
@@ -181,7 +183,11 @@ def main():
     global_params.DEBUG_MODE = 1 if args.debug else 0
     global_params.GENERATE_TEST_CASES = 1 if args.generate_test_cases else 0
     global_params.PARALLEL = 1 if args.parallel else 0
-
+    
+    if args.target_contracts and args.bytecode:
+        parser.error('Targeted contracts cannot be specifed when the bytecode is provided (Instead of Solidity source code).')
+    global_params.TARGET_CONTRACTS = args.target_contracts
+    
     if args.depth_limit:
         global_params.DEPTH_LIMIT = args.depth_limit
     if args.gas_limit:


### PR DESCRIPTION
This adds a new option `--target-contracts` that allows users to specify the targeted contracts to be processed. Before this PR, Oyente processes all contracts in the given Solidity source code.

This fixes #397.
This PR is to be tested by @Qiana0223 .