### PR TITLE
feat: support new solc & UTF-8

### DIFF
--- a/oyente/input_helper.py
+++ b/oyente/input_helper.py
@@ -152,7 +152,7 @@ class InputHelper:
         return evm_without_hash
 
     def _extract_bin_str(self, s, err=''):
-        binary_regex = r"\n======= (.*?) =======\nBinary of the runtime part: \n(.*?)\n"
+        binary_regex = r"\n======= (.*?) =======\nBinary of the runtime part: ?\n(.*?)\n"
         contracts = re.findall(binary_regex, s)
         contracts = [contract for contract in contracts if contract[1]]
         if not contracts:

--- a/oyente/source_map.py
+++ b/oyente/source_map.py
@@ -15,8 +15,8 @@ class Source:
         self.line_break_positions = self._load_line_break_positions()
 
     def _load_content(self):
-        with open(self.filename, 'r') as f:
-            content = f.read()
+        with open(self.filename, 'rb') as f:
+            content = f.read().decode('UTF-8')
         return content
 
     def _load_line_break_positions(self):

--- a/oyente/symExec.py
+++ b/oyente/symExec.py
@@ -278,7 +278,7 @@ def mapping_non_push_instruction(current_line_content, current_ins_address, idx,
                 idx += 1
                 break;
             else:
-                raise Exception("Source map error")
+                raise RuntimeError(F"Source map error, unknown name({name}) or instr_name({instr_name})")
     return idx
 
 # 1. Parse the disassembled file


### PR DESCRIPTION
After this PR, the latest known supported solc version is `0.5.4` with `evm` toolchain version `1.8.16`. Meanwhile, Solidity file containing non-ascii text will be supported.

Thanks @mstad and @Mayur1496 for reporting and testing (in #393 ).

Note that the version detection in Oyente is still unmodified as we plan to enhance the supported version detection later.

This might be the first PR breaking python 2 support and partially support python > 3 and < 3.6.