### PR TITLE
fix: CLI verbose mode ineffective when logging is configured before

### DIFF
--- a/oyente/oyente.py
+++ b/oyente/oyente.py
@@ -169,10 +169,14 @@ def main():
     if args.timeout:
         global_params.TIMEOUT = args.timeout
 
+    logging.basicConfig()
+    rootLogger = logging.getLogger(None)
+    
     if args.verbose:
-        logging.basicConfig(level=logging.DEBUG)
+        rootLogger.setLevel(level=logging.DEBUG)
     else:
-        logging.basicConfig(level=logging.INFO)
+        rootLogger.setLevel(level=logging.INFO)
+
     global_params.PRINT_PATHS = 1 if args.paths else 0
     global_params.REPORT_MODE = 1 if args.report else 0
     global_params.USE_GLOBAL_BLOCKCHAIN = 1 if args.globalblockchain else 0


### PR DESCRIPTION
This fixes the ineffective setting of logging level when logging library has been configured before entering our CLI entry point function.